### PR TITLE
Fix #29 and #30

### DIFF
--- a/src/main/java/teksturepako/greenery/common/command/CommandGreenery.kt
+++ b/src/main/java/teksturepako/greenery/common/command/CommandGreenery.kt
@@ -10,6 +10,7 @@ import net.minecraft.util.text.Style
 import net.minecraft.util.text.TextComponentString
 import net.minecraft.util.text.TextFormatting
 import teksturepako.greenery.Greenery
+import teksturepako.greenery.common.config.Config
 import teksturepako.greenery.common.config.json.arbBlock.ArbBlockParser
 import teksturepako.greenery.common.config.json.plant.PlantParser
 
@@ -33,10 +34,10 @@ class CommandGreenery : CommandBase()
             ArbBlockParser.decodeOrReloadData()
 
             Greenery.plantGenerators.clear()
-            Greenery.loadPlantGenerators(true)
+            Greenery.loadPlantGenerators(Config.global.printDebugInfo)
 
             Greenery.arbBlockGenerators.clear()
-            Greenery.loadArbBlockGenerators(true)
+            Greenery.loadArbBlockGenerators(Config.global.printDebugInfo)
 
             sender.sendMessage(TextComponentString("Plant configuration reloaded!").setStyle(Style().setColor(TextFormatting.GREEN)))
         }

--- a/src/main/java/teksturepako/greenery/common/config/Config.kt
+++ b/src/main/java/teksturepako/greenery/common/config/Config.kt
@@ -37,6 +37,6 @@ object Config
         @Name("[6] Print Debug Info")
         @Comment("Prints debug info to the log file.")
         @JvmField
-        var printDebugInfo = false
+        var printDebugInfo = true
     }
 }

--- a/src/main/java/teksturepako/greenery/common/config/Config.kt
+++ b/src/main/java/teksturepako/greenery/common/config/Config.kt
@@ -33,5 +33,10 @@ object Config
         @Comment("Whether to generate plants in the superflat world type.")
         @JvmField
         var genInSuperflat = true
+
+        @Name("[6] Print Debug Info")
+        @Comment("Prints debug info to the log file.")
+        @JvmField
+        var printDebugInfo = false
     }
 }

--- a/src/main/java/teksturepako/greenery/common/config/parser/DropsParser.kt
+++ b/src/main/java/teksturepako/greenery/common/config/parser/DropsParser.kt
@@ -9,6 +9,7 @@ import net.minecraft.world.IBlockAccess
 import net.minecraft.world.World
 import net.minecraftforge.common.ForgeHooks
 import net.minecraftforge.fml.common.registry.ForgeRegistries
+import net.minecraftforge.oredict.OreDictionary
 import teksturepako.greenery.common.util.Utils.isNotNull
 
 object DropsParser
@@ -57,7 +58,14 @@ object DropsParser
             // Parsing itemStack
             val itemStack: ItemStack = if (itemStackRaw.isNotNull(0) && itemStackRaw.isNotNull(1))
             {
-                ItemStack(ForgeRegistries.ITEMS.getValue(ResourceLocation("${itemStackRaw[0]}:${itemStackRaw[1]}"))!!)
+                if (itemStackRaw[0] == "ore")
+                {
+                    OreDictionary.getOres(itemStackRaw[1]).firstOrNull() ?: ItemStack.EMPTY
+                }
+                else
+                {
+                    ItemStack(ForgeRegistries.ITEMS.getValue(ResourceLocation("${itemStackRaw[0]}:${itemStackRaw[1]}"))!!)
+                }
             }
             else
             {
@@ -72,6 +80,16 @@ object DropsParser
                     else -> ItemStack.EMPTY
                 }
             }
+
+            // Setting metadata if it's not an oredict item
+            if (itemStackRaw[0] != "ore" && itemStackRaw.isNotNull(2))
+            {
+                itemStack.itemDamage = itemStackRaw[2].toInt()
+            }
+
+            // Fix itemDamage overflow
+            // Encountered when using 'ore:plankWood' or 'ore:logWood' as drop
+            if (itemStack.itemDamage == 32767) itemStack.itemDamage = 0
 
             // Setting count
             itemStack.count = amount + fortune

--- a/src/main/java/teksturepako/greenery/common/event/EventConfigChanged.kt
+++ b/src/main/java/teksturepako/greenery/common/event/EventConfigChanged.kt
@@ -25,10 +25,10 @@ object EventConfigChanged
             ConfigManager.sync(Greenery.MODID, Config.Type.INSTANCE)
 
             Greenery.plantGenerators.clear()
-            Greenery.loadPlantGenerators(GreeneryConfig.global.printDebugInfo)
+            Greenery.loadPlantGenerators(false)
 
             Greenery.arbBlockGenerators.clear()
-            Greenery.loadArbBlockGenerators(GreeneryConfig.global.printDebugInfo)
+            Greenery.loadArbBlockGenerators(false)
 
             printed = if (!printed)
             {

--- a/src/main/java/teksturepako/greenery/common/event/EventConfigChanged.kt
+++ b/src/main/java/teksturepako/greenery/common/event/EventConfigChanged.kt
@@ -24,15 +24,15 @@ object EventConfigChanged
             ConfigManager.sync(Greenery.MODID, Config.Type.INSTANCE)
 
             Greenery.plantGenerators.clear()
-            Greenery.loadPlantGenerators(false)
+            Greenery.loadPlantGenerators(teksturepako.greenery.common.config.Config.global.printDebugInfo)
 
             Greenery.arbBlockGenerators.clear()
-            Greenery.loadArbBlockGenerators(false)
+            Greenery.loadArbBlockGenerators(teksturepako.greenery.common.config.Config.global.printDebugInfo)
 
             printed = if (!printed)
             {
-                GeneratorParser.parseGenerators(plantGenerators.map { it.plant.localizedName to it.plant.worldGen }, true)
-                GeneratorParser.parseGenerators(arbBlockGenerators.map { it.name to it.worldGen }, true)
+                GeneratorParser.parseGenerators(plantGenerators.map { it.plant.localizedName to it.plant.worldGen }, teksturepako.greenery.common.config.Config.global.printDebugInfo)
+                GeneratorParser.parseGenerators(arbBlockGenerators.map { it.name to it.worldGen }, teksturepako.greenery.common.config.Config.global.printDebugInfo)
                 true
             }
             else false

--- a/src/main/java/teksturepako/greenery/common/event/EventConfigChanged.kt
+++ b/src/main/java/teksturepako/greenery/common/event/EventConfigChanged.kt
@@ -9,6 +9,7 @@ import teksturepako.greenery.Greenery
 import teksturepako.greenery.Greenery.arbBlockGenerators
 import teksturepako.greenery.Greenery.plantGenerators
 import teksturepako.greenery.common.config.parser.GeneratorParser
+import teksturepako.greenery.common.config.Config as GreeneryConfig
 
 @Mod.EventBusSubscriber
 object EventConfigChanged
@@ -24,15 +25,15 @@ object EventConfigChanged
             ConfigManager.sync(Greenery.MODID, Config.Type.INSTANCE)
 
             Greenery.plantGenerators.clear()
-            Greenery.loadPlantGenerators(teksturepako.greenery.common.config.Config.global.printDebugInfo)
+            Greenery.loadPlantGenerators(GreeneryConfig.global.printDebugInfo)
 
             Greenery.arbBlockGenerators.clear()
-            Greenery.loadArbBlockGenerators(teksturepako.greenery.common.config.Config.global.printDebugInfo)
+            Greenery.loadArbBlockGenerators(GreeneryConfig.global.printDebugInfo)
 
             printed = if (!printed)
             {
-                GeneratorParser.parseGenerators(plantGenerators.map { it.plant.localizedName to it.plant.worldGen }, teksturepako.greenery.common.config.Config.global.printDebugInfo)
-                GeneratorParser.parseGenerators(arbBlockGenerators.map { it.name to it.worldGen }, teksturepako.greenery.common.config.Config.global.printDebugInfo)
+                GeneratorParser.parseGenerators(plantGenerators.map { it.plant.localizedName to it.plant.worldGen }, GreeneryConfig.global.printDebugInfo)
+                GeneratorParser.parseGenerators(arbBlockGenerators.map { it.name to it.worldGen }, GreeneryConfig.global.printDebugInfo)
                 true
             }
             else false

--- a/src/main/java/teksturepako/greenery/common/worldGen/WorldGenHook.kt
+++ b/src/main/java/teksturepako/greenery/common/worldGen/WorldGenHook.kt
@@ -16,7 +16,7 @@ internal class WorldGenHook : IWorldGenerator
         val plantGenerators: MutableList<IPlantGenerator> = Greenery.loadPlantGenerators(true)
         for (generator in plantGenerators) generator.generate(rand, chunkX, chunkZ, world, chunkGen, chunkProv)
 
-        val arbBlockGenerators: MutableList<IArbBlockGenerator> = Greenery.loadArbBlockGenerators(true)
+        val arbBlockGenerators: MutableList<IArbBlockGenerator> = Greenery.loadArbBlockGenerators(Config.global.printDebugInfo)
         for (generator in arbBlockGenerators) generator.generate(rand, chunkX, chunkZ, world, chunkGen, chunkProv)
 
         if (Config.global.removeGrass) removeUnwantedBopGenerators(world)


### PR DESCRIPTION
What does this Pull-Request do?
- tweaks `DropsParser` to allow defining drops with meta data -> use `minecraft:wool:5`
- tweaks `DropsParser` to allow defining drops as oredicts -> use `ore:plankWood`
  - adds an additional check if the oredicts returns an itemstack with a wildcard value and fixes it if it happens
  - this happens for example when using `ore:logWood` or `ore:plankWood`
- added a new config option for printing all debug messages to the log file (off by default)
- changed all calls to the debug printing to respect the new config option